### PR TITLE
App did not have install property set

### DIFF
--- a/lockdown.groovy
+++ b/lockdown.groovy
@@ -87,7 +87,7 @@ def refreshTime = [
 
 
 preferences {
-	page(name: "pageOne", title: "", uninstall: true) {
+	page(name: "pageOne", title: "", install:true, uninstall: true) {
 		section(getFormat("title", "${app.label}")) {
 				paragraph "Automatically lock a group of doors, with auto-refresh, timing delays, and retries.  It is triggered by a triggering switch (which can be real or virtual).  The triggering switch is reset when the process is complete."
 			}


### PR DESCRIPTION
Not sure if this was a change in recent hub firmware, but this code when added to Hubitat does not have a "Done" button. Adding this in fixes it and allows it to be installed. I got the tip from this link: https://community.hubitat.com/t/done-button-missing-from-custom-app/7998/3